### PR TITLE
Depend on major version 2 of selenium-webdriver

### DIFF
--- a/rubium-ios.gemspec
+++ b/rubium-ios.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
 
   # runtime dependencies (used to generate Gemfile)
-  s.add_runtime_dependency 'selenium-webdriver', '~> 2.42.0'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 2.42'
   s.add_runtime_dependency 'activesupport', '~> 3.0'
 end


### PR DESCRIPTION
This change allows rubium-ios to be installed alongside appium_lib version 7.0, which requires selenium-webdriver >= 2.45.

I think this version change more closely aligns with what is necessary, too, since minor versions should remain backward compatible. It also lines up with what appium_lib is doing.
